### PR TITLE
Run end after screenshot for buffer support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,8 +21,7 @@ export default function(tweetUrl, filePath) {
   .then(hasIframe => hasIframe && nightmare.waitUntilVisible(iframeSelector))
   .then(() => nightmare.style(tweetSelector, { borderRadius: "0px" })) // Ensure tweet completely fills screenshot.
   .then(() => nightmare.boundingBox(tweetSelector))
-  .then(boundingBox => nightmare.screenshot(filePath, boundingBox))
-  .then(() => nightmare.end());
+  .then(boundingBox => nightmare.screenshot(filePath, boundingBox).end());
 }
 
 Nightmare.action("waitUntilVisible", function(selector, done) {


### PR DESCRIPTION
This simple change allows the `Buffer` to be returned from the `screenshot` call if `filePath` is set null, which lets me bypass writing images to disk.