### PR TITLE
[nightmare > puppeteer]

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,66 +1,16 @@
-import Nightmare from "nightmare";
-import twitterUrlParser from "twitter-url-parser";
+require('regenerator-runtime/runtime');
+const puppeteer = require('puppeteer');
 
-export default function(tweetUrl, filePath) {
-  return new Promise((resolve, reject) => {
-    const tweetId = (() => {
-      try {
-        return twitterUrlParser(tweetUrl).id;
-      } catch (error) {
-        throw new Error('Invalid tweet URL.');
-      }
-    })();
-    const tweetSelector = `.tweet[data-tweet-id="${tweetId}"]`;
-    const sensitivityButtonSelector = `${tweetSelector} button.js-display-this-media`;
-    const mediaSelector = `${tweetSelector} .AdaptiveMedia`;
-    const iframeSelector = `${tweetSelector} iframe`;
-    const nightmare = new Nightmare();
-
-    Promise.resolve()
-    .then(() => nightmare.viewport(2000, 2000))
-    .then(() => nightmare.goto(tweetUrl))
-    .then(() => nightmare.wait(() => document.readyState === "complete"))
-    .then(() => nightmare.exists(tweetSelector))
-    .then(hasTweet => { if (!hasTweet) throw new Error('Tweet does not exist!') })
-    .then(() => nightmare.exists(sensitivityButtonSelector))
-    .then(hasSensitivityButton => hasSensitivityButton && nightmare.click(sensitivityButtonSelector))
-    .then(() => nightmare.exists(mediaSelector))
-    .then(hasMedia => hasMedia && nightmare.waitUntilVisible(mediaSelector))
-    .then(() => nightmare.exists(iframeSelector))
-    .then(hasIframe => hasIframe && nightmare.waitUntilVisible(iframeSelector))
-    .then(() => nightmare.style(tweetSelector, { borderRadius: "0px" })) // Ensure tweet completely fills screenshot.
-    .then(() => nightmare.boundingBox(tweetSelector))
-    .then(boundingBox => nightmare.screenshot(filePath, boundingBox).end())
-    .then(resolve)
-    .catch(reject);
+export default async function(tweetUrl, filePath) {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  await page.setViewport({
+    width: 720,
+    height: 1024,
+    deviceScaleFactor: 1,
+    isMobile: true,
   });
+  await page.goto(tweetUrl, { waitUntil: 'networkidle0', timeout: 10000 });
+  await page.screenshot({path: filePath});
+  await browser.close();
 }
-
-Nightmare.action("waitUntilVisible", function(selector, done) {
-  this.wait(selector).then(() => (
-    this.wait(selector => {
-      const element = document.querySelector(selector);
-      return element.offsetWidth > 0 && element.offsetHeight > 0;
-    }, selector)
-  )).then(done);
-});
-
-Nightmare.action("style", function(selector, style, done) {
-  this.evaluate_now((selector, style) => {
-    const element = document.querySelector(selector);
-    Object.assign(element.style, style);
-  }, done, selector, style);
-});
-
-Nightmare.action("boundingBox", function(selector, done) {
-  this.evaluate_now(selector => {
-    const element = document.querySelector(selector);
-    const rectangle = element.getBoundingClientRect();
-    return {
-      x: Math.round(rectangle.left),
-      y: Math.round(rectangle.top),
-      width: Math.round(rectangle.width),
-      height: Math.round(rectangle.height),
-    };
-  }, done, selector);
-});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screenshot-tweet",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Screenshot a Twitter tweet.",
   "author": "Luke Horvat",
   "license": "MIT",
@@ -13,17 +13,16 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "chalk": "1.1.3",
-    "nightmare": "2.8.1",
-    "tildify": "1.2.0",
-    "twitter-url-parser": "0.0.1",
-    "yargs": "4.6.0"
+    "chalk": "~4.0.0",
+    "puppeteer": "~3.0.4",
+    "tildify": "~2.0.0",
+    "yargs": "~15.3.1"
   },
   "devDependencies": {
-    "@babel/cli": "7.1.0",
-    "@babel/core": "7.1.0",
-    "@babel/preset-env": "7.1.0",
-    "rimraf": "2.6.2"
+    "@babel/cli": "~7.8.4",
+    "@babel/core": "~7.9.6",
+    "@babel/preset-env": "~7.9.6",
+    "rimraf": "~3.0.2"
   },
   "keywords": [
     "twitter",


### PR DESCRIPTION
* Moves from `nightmare` to `puppeteer` and gets this functional again.
* Sets width/height - not ideal but does get it functional.
* Tested locally with `npm i && npm link && screenshot-tweet`.
* Removes `nightmare` and `twitter-url-parser` as they are no longer used.
* Bumps all dependency versions.